### PR TITLE
Reformat top level function declarations to merge return types with names

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -156,11 +156,9 @@ std::vector<std::condition_variable*> cvArray;
 /* Protects isIdledArray so cores do not get idled multiple times */
 SpinLock coreIdlerLock("coreIdlerLock", false);
 
-void
-idleCorePrivate(int coreId);
+void idleCorePrivate(int coreId);
 
-void
-descheduleCore();
+void descheduleCore();
 /**
  * All core-specific state that is not associated with other classes.
  */

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -66,8 +66,7 @@ extern int stackSize;
 
 // Used in inline functions.
 extern FILE* errorStream;
-void
-dispatch();
+void dispatch();
 
 // Used for user per-core data structure initialization.
 extern std::function<void()> initCore;
@@ -131,26 +130,18 @@ struct ThreadId {
     bool operator!() const { return *this == ThreadId(); }
 };
 
-void
-init(CorePolicy* initCorePolicy, int* argcp = NULL, const char** argv = NULL);
-void
-shutDown();
-void
-waitForTermination();
-void
-yield();
-void
-sleep(uint64_t ns);
+void init(CorePolicy* initCorePolicy, int* argcp = NULL,
+          const char** argv = NULL);
+void shutDown();
+void waitForTermination();
+void yield();
+void sleep(uint64_t ns);
 
-void
-idleCore(int coreId);
-void
-unidleCore(int coreId);
+void idleCore(int coreId);
+void unidleCore(int coreId);
 
-bool
-makeExclusiveOnCore(bool forScaleDown = false);
-void
-makeSharedOnCore();
+bool makeExclusiveOnCore(bool forScaleDown = false);
+void makeSharedOnCore();
 
 /**
  * Block the current thread until another thread invokes join() with the
@@ -160,19 +151,13 @@ inline void
 block() {
     dispatch();
 }
-void
-signal(ThreadId id);
-void
-join(ThreadId id);
-ThreadId
-getThreadId();
+void signal(ThreadId id);
+void join(ThreadId id);
+ThreadId getThreadId();
 
-void
-setErrorStream(FILE* ptr);
-void
-testInit();
-void
-testDestroy();
+void setErrorStream(FILE* ptr);
+void testInit();
+void testDestroy();
 
 /**
  * A resource which blocks the current thread until it is available.
@@ -449,17 +434,12 @@ const uint64_t COMPLETION_WAIT_TIME = 100000;
  */
 const uint8_t EXCLUSIVE = maxThreadsPerCore * 2 + 1;
 
-void
-schedulerMainLoop();
-void
-swapcontext(void** saved, void** target);
-void
-threadMain();
+void schedulerMainLoop();
+void swapcontext(void** saved, void** target);
+void threadMain();
 
-void
-incrementCoreCount();
-void
-decrementCoreCount();
+void incrementCoreCount();
+void decrementCoreCount();
 
 /// This structure tracks the live threads on a single core.
 struct MaskAndCount {

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -42,8 +42,8 @@ extern CoreArbiterClient* coreArbiter;
 
 CorePolicy* corePolicyTest;
 
-static void
-limitedTimeWait(std::function<bool()> condition, int numIterations = 1000);
+static void limitedTimeWait(std::function<bool()> condition,
+                            int numIterations = 1000);
 
 struct Environment : public ::testing::Environment {
     CoreArbiterServer* coreArbiterServer;

--- a/src/Common.h
+++ b/src/Common.h
@@ -86,8 +86,7 @@ struct Core {
     uint8_t highestOccupiedContext;
 };
 
-void*
-alignedAlloc(size_t size, size_t alignment = CACHE_LINE_SIZE);
+void* alignedAlloc(size_t size, size_t alignment = CACHE_LINE_SIZE);
 }  // namespace Arachne
 
 #endif

--- a/src/CorePolicy.cc
+++ b/src/CorePolicy.cc
@@ -69,8 +69,7 @@ const uint64_t MEASUREMENT_PERIOD = 50 * 1000 * 1000;
 /* Is the core load estimator running? */
 bool loadEstimatorRunning = false;
 
-void
-coreLoadEstimator(CorePolicy* corePolicy);
+void coreLoadEstimator(CorePolicy* corePolicy);
 
 /*
  * Choose a core to deschedule.  Return its coreId.

--- a/src/CorePolicyTest.cc
+++ b/src/CorePolicyTest.cc
@@ -43,8 +43,8 @@ extern CoreArbiterClient* coreArbiter;
 
 CorePolicy* corePolicyTest;
 
-static void
-limitedTimeWait(std::function<bool()> condition, int numIterations = 1000);
+static void limitedTimeWait(std::function<bool()> condition,
+                            int numIterations = 1000);
 
 struct Environment : public ::testing::Environment {
     CoreArbiterServer* coreArbiterServer;

--- a/src/SpinLock.h
+++ b/src/SpinLock.h
@@ -29,8 +29,7 @@ using PerfUtils::Cycles;
 // Forward declarations to resolve various circular dependencies of separating
 // this out.
 struct ThreadContext;
-void
-yield();
+void yield();
 extern thread_local Core core;
 
 /**


### PR DESCRIPTION
This is the current style we want to enforce.