### PR TITLE
Remove threadClass argument from createThread and createThreadOnCore

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -949,7 +949,8 @@ init(CorePolicy* arachneCorePolicy, int* argcp, const char** argv) {
     }
 
     // Block until minNumCores is active, per the application's requirements.
-    while (numActiveCores != minNumCores) usleep(1);
+    while (numActiveCores != minNumCores)
+        usleep(1);
 }
 
 /**
@@ -1111,7 +1112,8 @@ ConditionVariable::notifyOne() {
  */
 void
 ConditionVariable::notifyAll() {
-    while (!blockedThreads.empty()) notifyOne();
+    while (!blockedThreads.empty())
+        notifyOne();
 }
 
 /**
@@ -1219,8 +1221,7 @@ descheduleCore() {
     // hold it for too long.
     // If this creation fails, it would implies that we are overloaded and
     // should not ramp down.
-    if (createThreadOnCore(corePolicy->defaultClass, minCoreId, releaseCore) ==
-        NullThread) {
+    if (createThreadOnCore(minCoreId, releaseCore) == NullThread) {
         coreChangeActive = false;
         ARACHNE_LOG(WARNING, "Release core thread creation failed to %d!\n",
                     minCoreId);
@@ -1471,8 +1472,7 @@ idleCore(int coreId) {
     std::lock_guard<SpinLock> _(coreIdlerLock);
     if (!isIdledArray[coreId]) {
         isIdledArray[coreId] = true;
-        if (createThreadOnCore(corePolicy->defaultClass, coreId,
-                               idleCorePrivate, coreId) == NullThread) {
+        if (createThreadOnCore(coreId, idleCorePrivate, coreId) == NullThread) {
             ARACHNE_LOG(ERROR, "Error creating idleCorePrivate thread\n");
         }
     }

--- a/src/CorePolicy.cc
+++ b/src/CorePolicy.cc
@@ -105,8 +105,7 @@ CorePolicy::addCore(int coreId) {
     // This function bootstraps the coreLoadEstimator as soon as it has a core.
     if (!loadEstimatorRunning && !Arachne::disableLoadEstimation) {
         loadEstimatorRunning = true;
-        Arachne::createThread(defaultClass, &CorePolicy::coreLoadEstimator,
-                              this);
+        Arachne::createThread(&CorePolicy::coreLoadEstimator, this);
     }
 }
 


### PR DESCRIPTION
This change makes createThread default to creating a thread with threadClass
equal to 0.