### PR TITLE
C wrapper for Arachne

### DIFF
--- a/cwrapper/CArachneWrapper.cc
+++ b/cwrapper/CArachneWrapper.cc
@@ -1,0 +1,92 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+
+#include "Arachne.h"
+#include "CArachneWrapper.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This function is the wrapper for Arachne::init
+ */
+void
+cArachneInit(int* argcp, const char** argv) {
+    Arachne::init(argcp, argv);
+}
+
+/**
+ * This function is the wrapper for Arachne::shutDown
+ */
+void
+cArachneShutDown() {
+    Arachne::shutDown();
+}
+
+/**
+ * This function is the wrapper for Arachne::waitForTermination
+ */
+void
+cArachneWaitForTermination() {
+    Arachne::waitForTermination();
+}
+
+/**
+ * This function is the wrapper for Arachne::createThread.
+ * We have changed the interface due to no template support in C.
+ *
+ * \param id
+ *      The pointer to store returned thread id
+ * \param startRoutine
+ *      The main function for the new thread
+ * \param arg
+ *      The argument list for startRoutine
+ * \return
+ *      The return value is 0 on success and store the thread id in *thread.
+ *      It returns -1 if there are insufficient resources for creating
+ *      a new thread, and the contents of *thread would be undefined.
+ */
+int
+cArachneCreateThread(CArachneThreadId* id, void* (*startRoutine)(void*),
+                     void* arg) {
+    Arachne::ThreadId tid = Arachne::createThread(startRoutine, arg);
+    if (tid == Arachne::NullThread) {
+        return -1;
+    }
+
+    id->context = reinterpret_cast<CArachneThreadContext*>(tid.context);
+    id->generation = tid.generation;
+    return 0;
+}
+
+/**
+ * This function is the wrapper for Arachne::join.
+ *
+ * \param id
+ *      The pointer to the id of the thread to join.
+ */
+void
+cArachneJoin(CArachneThreadId* id) {
+    Arachne::ThreadId tid(
+        reinterpret_cast<Arachne::ThreadContext*>(id->context), id->generation);
+    Arachne::join(tid);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cwrapper/CArachneWrapper.h
+++ b/cwrapper/CArachneWrapper.h
@@ -1,0 +1,59 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef CARACHNEWRAPPER_H_
+#define CARACHNEWRAPPER_H_
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup api Arachne C Wrapper
+ * In order to use Arachne in applications written in C, we provide C wrappers
+ * for Arachne public API functions
+ * @{
+ */
+/**
+ * This structure is the C wrapper for Arachne::ThreadContext
+ * and can only be used as pointers.
+ */
+struct CArachneThreadContext;
+typedef struct CArachneThreadContext CArachneThreadContext;
+/**
+ * This structure is the C wrapper for Arachne::ThreadId.
+ */
+struct CArachneThreadId {
+    CArachneThreadContext* context;
+    uint32_t generation;
+};
+typedef struct CArachneThreadId CArachneThreadId;
+
+void cArachneInit(int* argcp, const char** argv);
+void cArachneShutDown();
+void cArachneWaitForTermination();
+int cArachneCreateThread(CArachneThreadId* id, void* (*startRoutine)(void*),
+                         void* arg);
+void cArachneJoin(CArachneThreadId* id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CARACHNEWRAPPER_H_

--- a/cwrapper/CArachneWrapperCTest.c
+++ b/cwrapper/CArachneWrapperCTest.c
@@ -1,0 +1,194 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "CArachneWrapper.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+enum TestReturn { TEST_PASS, TEST_FAIL };
+typedef enum TestReturn TestReturn;
+
+/**
+ * Functions below are used to test thread creation
+ */
+static void*
+funcCreateTest(void* arg) {
+    /*
+     * We sleep 1ms here so that threads joining this thread
+     * must contend for the join lock with high probability.
+     */
+    usleep(1000);
+    *(unsigned*)arg = 0xDEADBEEF;
+    return NULL;
+}
+
+static TestReturn
+createThreadTest(void) {
+    CArachneThreadId threadId;
+    unsigned arg = 0;
+    TestReturn retval = TEST_PASS;
+
+    cArachneInit(NULL, NULL);
+    int ret = cArachneCreateThread(&threadId, funcCreateTest, (void*)&arg);
+    assert(ret == 0);
+
+    cArachneJoin(&threadId);
+    if (arg != 0xDEADBEEF) {
+        retval = TEST_FAIL;
+    }
+
+    return retval;
+}
+
+/**
+ * Structures are used to collect all test cases
+ */
+typedef TestReturn (*TEST_FUNC)(void);
+struct testcase {
+    const char* description;
+    TEST_FUNC function;
+};
+
+struct testcase testcases[] = {{"createThread", createThreadTest},
+                               {NULL, NULL}};
+
+/*
+ * Wrapper for main function arguments
+ */
+struct ArgList {
+    int argc;
+    char** argv;
+};
+typedef struct ArgList ArgList;
+
+/**
+ * Main entrance for all tests
+ */
+static void*
+mainTestLoop(void* arg) {
+    int exitcode = 0;
+    int id = 0, numCases = 0;
+
+    for (numCases = 0; testcases[numCases].description; numCases++) {
+        /* Counting the number of cases*/
+    }
+
+    printf("Testing cases 1..%d\n", numCases);
+
+    for (id = 0; id < numCases; id++) {
+        fflush(stdout);
+        TestReturn ret = testcases[id].function();
+        if (ret == TEST_PASS) {
+            fprintf(stdout, "[OK] %d - %s\n", id + 1,
+                    testcases[id].description);
+        } else {
+            fprintf(stdout, "[ERROR] %d - %s\n", id + 1,
+                    testcases[id].description);
+            exitcode += 1;
+        }
+        fflush(stdout);
+    }
+
+    if (exitcode != 0) {
+        fprintf(stderr, "Non-zero return code for %d / %d tests \n", exitcode,
+                numCases);
+    }
+    cArachneShutDown();
+    return NULL;
+}
+
+/*
+ * Start a CoreArbiter server
+ * Return 0 on success, return -1 on error.
+ */
+static int
+startCoreArbiter(void) {
+    char cmd[] = "../CoreArbiter/bin/coreArbiterServer > /dev/null 2>&1 &";
+    char advisoryPath[] = "/tmp/coreArbiterAdvisoryLock";
+    int retval = 0;
+    char chr = 0;
+
+    system(cmd);
+    int readFd = open(advisoryPath, O_RDONLY);
+    if (readFd < 0) {
+        fprintf(stderr, "Failed to open advisoryPath %s: %s \n", advisoryPath,
+                strerror(errno));
+        return -1;
+    }
+
+    /* Check server started or not, wait at most 1 sec */
+    ssize_t ret;
+    for (int i = 0; i < 1000; ++i) {
+        ret = read(readFd, &chr, 1);
+        if (ret > 0) {
+            break;
+        } else {
+            usleep(1000);
+        }
+    }
+
+    if ((ret == 1) && (chr == 's')) {
+        retval = 0;
+    } else {
+        if (ret < 0) {
+            fprintf(stderr, "Failed to read advisoryPath %s: %s \n",
+                    advisoryPath, strerror(errno));
+        } else {
+            fprintf(stderr, "Timed out waiting for server start \n");
+        }
+        retval = -1;
+    }
+
+    close(readFd);
+    return retval;
+}
+
+/*
+ * Create main thread
+ */
+int
+main(int argc, char** argv) {
+    CArachneThreadId threadId;
+    int retval = 0;
+    ArgList mainArgs;
+
+    mainArgs.argc = argc;
+    mainArgs.argv = argv;
+
+    retval = startCoreArbiter();
+    if (retval == -1) {
+        fprintf(stderr, "Faild to start CoreArbiter server! \n");
+        exit(1);
+    }
+
+    cArachneInit(&argc, (const char**)argv);
+    retval = cArachneCreateThread(&threadId, mainTestLoop, (void*)&mainArgs);
+    if (retval == -1) {
+        fprintf(stderr, "Failed to create main Arachne thread!\n");
+    } else {
+        cArachneWaitForTermination();
+    }
+
+    system("kill $(pidof coreArbiterServer)");
+    return retval;
+}

--- a/cwrapper/CArachneWrapperTest.cc
+++ b/cwrapper/CArachneWrapperTest.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <thread>
+#include "PerfUtils/Cycles.h"
+#include "gtest/gtest.h"
+
+#define private public
+#define protected public
+#include "Arachne.h"
+#include "CArachneWrapper.h"
+#include "CoreArbiter/ArbiterClientShim.h"
+#include "CoreArbiter/CoreArbiterClient.h"
+#include "CoreArbiter/CoreArbiterServer.h"
+#include "CoreArbiter/Logger.h"
+#include "CoreArbiter/MockSyscall.h"
+#include "CorePolicy.h"
+
+namespace Arachne {
+
+using CoreArbiter::CoreArbiterClient;
+using CoreArbiter::CoreArbiterServer;
+using CoreArbiter::MockSyscall;
+
+extern bool useCoreArbiter;
+
+extern std::atomic<uint32_t> numActiveCores;
+extern volatile uint32_t minNumCores;
+extern int* virtualCoreTable;
+
+extern CoreArbiterClient* coreArbiter;
+
+static void limitedTimeWait(std::function<bool()> condition,
+                            int numIterations = 1000);
+
+struct Environment : public ::testing::Environment {
+    CoreArbiterServer* coreArbiterServer;
+    MockSyscall* sys;
+
+    std::thread* coreArbiterServerThread;
+    // Override this to define how to set up the environment.
+    virtual void SetUp() {
+        // Initalize core arbiter server
+        CoreArbiter::Logger::setLogLevel(CoreArbiter::WARNING);
+        sys = new MockSyscall();
+        sys->callGeteuid = false;
+        sys->geteuidResult = 0;
+        CoreArbiterServer::testingSkipCpusetAllocation = true;
+
+        CoreArbiterServer::sys = sys;
+        coreArbiterServer = new CoreArbiterServer(std::string(TEST_SOCKET),
+                                                  std::string(TEST_MEM),
+                                                  {1, 2, 3, 4, 5, 6, 7}, false);
+        coreArbiterServerThread =
+            new std::thread([=] { coreArbiterServer->startArbitration(); });
+    }
+    // Override this to define how to tear down the environment.
+    virtual void TearDown() {
+        coreArbiterServer->endArbitration();
+        coreArbiterServerThread->join();
+        delete coreArbiterServerThread;
+        delete coreArbiterServer;
+        delete sys;
+    }
+};
+
+::testing::Environment* const testEnvironment =
+    (useCoreArbiter) ? ::testing::AddGlobalTestEnvironment(new Environment)
+                     : NULL;
+
+struct ArachneTest : public ::testing::Test {
+    virtual void SetUp() {
+        Arachne::minNumCores = 1;
+        Arachne::maxNumCores = 3;
+        Arachne::disableLoadEstimation = true;
+        ::cArachneInit(NULL, NULL);
+        // Artificially wake up all threads for testing purposes
+        std::vector<uint32_t> coreRequest({3, 0, 0, 0, 0, 0, 0, 0});
+        coreArbiter->setRequestedCores(coreRequest);
+        limitedTimeWait([]() -> bool { return numActiveCores == 3; });
+    }
+
+    virtual void TearDown() {
+        // Unblock all cores so they can shut down and be joined.
+        coreArbiter->setRequestedCores(
+            {Arachne::maxNumCores, 0, 0, 0, 0, 0, 0, 0});
+
+        ::cArachneShutDown();
+        ::cArachneWaitForTermination();
+    }
+};
+
+// Helper function for tests with timing dependencies, so that we wait for a
+// finite amount of time in the case of a bug causing an infinite loop.
+static void
+limitedTimeWait(std::function<bool()> condition, int numIterations) {
+    for (int i = 0; i < numIterations; i++) {
+        if (condition()) {
+            break;
+        }
+        usleep(1000);
+    }
+    // We use assert here because an infinite loop will result in TearDown
+    // not being able to complete, so we might as well terminate the tests here.
+    ASSERT_TRUE(condition());
+}
+
+// Functions below are used to test thread creation
+static void*
+funcCreateTest(void* arg) {
+    // We sleep 1ms here so that threads joining this thread
+    // must contend for the join lock with high probability.
+    usleep(1000);
+    *reinterpret_cast<unsigned*>(arg) = 0xDEADBEEF;
+    return NULL;
+}
+
+TEST_F(ArachneTest, CWrapper_createThread) {
+    Arachne::testInit();
+    CArachneThreadId threadId;
+    unsigned arg = 0;
+    int ret = cArachneCreateThread(&threadId, funcCreateTest,
+                                   reinterpret_cast<void*>(&arg));
+    EXPECT_EQ(0, ret);
+
+    cArachneJoin(&threadId);
+    EXPECT_EQ(0xDEADBEEF, arg);
+    Arachne::testDestroy();
+}
+
+}  // namespace Arachne


### PR DESCRIPTION
I added C wrapper for Arachne public API.

Currently it supports `init`, `shutDown`, `waitForTermination`, `createThread`, and `join`.
Will add more in the future. All C wrapper structures have the prefix `CArachne` and all wrapper functions have the prefix `cArachne`.

CArachneWrapperTest.cc is the unit test file in C++.
CArachneWrapperCTest.c is the test file in C.

Now we can use `make ctest` to run tests written in C.