### PR TITLE
Catch and handle exceptions thrown by Arachne::init

### DIFF
--- a/cwrapper/CArachneWrapper.cc
+++ b/cwrapper/CArachneWrapper.cc
@@ -13,10 +13,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <errno.h>
 #include <stdio.h>
 
 #include "Arachne.h"
 #include "CArachneWrapper.h"
+#include "CoreArbiter/CoreArbiterClient.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,10 +26,22 @@ extern "C" {
 
 /**
  * This function is the wrapper for Arachne::init
+ *
+ * \return
+ *      The return value is 0 on success and -1 on error. Errno will be set
  */
-void
+int
 cArachneInit(int* argcp, const char** argv) {
-    Arachne::init(argcp, argv);
+    int retval = 0;
+
+    // Capture the exception threw by Arachne::init
+    try {
+        Arachne::init(argcp, argv);
+    } catch (const CoreArbiter::CoreArbiterClient::ClientException& e) {
+        retval = -1;
+        errno = ECONNREFUSED;  // Set errno to "Connection refused"
+    }
+    return retval;
 }
 
 /**

--- a/cwrapper/CArachneWrapper.h
+++ b/cwrapper/CArachneWrapper.h
@@ -45,7 +45,7 @@ struct CArachneThreadId {
 };
 typedef struct CArachneThreadId CArachneThreadId;
 
-void cArachneInit(int* argcp, const char** argv);
+int cArachneInit(int* argcp, const char** argv);
 void cArachneShutDown();
 void cArachneWaitForTermination();
 int cArachneCreateThread(CArachneThreadId* id, void* (*startRoutine)(void*),

--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -917,7 +917,7 @@ void
 init(int* argcp, const char** argv) {
     if (initialized)
         return;
-    initialized = true;
+
     parseOptions(argcp, argv);
 
     coreArbiter = (useCoreArbiter) ? CoreArbiterClient::getInstance(TEST_SOCKET)
@@ -982,6 +982,10 @@ init(int* argcp, const char** argv) {
     // Block until minNumCores is active, per the application's requirements.
     while (numActiveCores != minNumCores)
         usleep(1);
+
+    // Only consider Arachne initialized if we've successfully parsed options
+    // allocated all resources, and connected to the CoreArbiter
+    initialized = true;
 }
 
 /**


### PR DESCRIPTION
cArachneInit() would catch the errors thrown by Arachne::init(),
set errno to Connection Refused, and set the return value to be -1.
It may take CoreArbiter server a while to fully prepared.
So the application can retry several times to initialize Arachne.