### PR TITLE
Change TEST_SOCKET and TEST_MEM locations.

### DIFF
--- a/cwrapper/arachne_wrapper_test.cc
+++ b/cwrapper/arachne_wrapper_test.cc
@@ -40,6 +40,7 @@ extern std::atomic<uint32_t> numActiveCores;
 extern volatile uint32_t minNumCores;
 extern int* virtualCoreTable;
 
+extern std::string coreArbiterSocketPath;
 extern CoreArbiterClient* coreArbiter;
 
 static void limitedTimeWait(std::function<bool()> condition,
@@ -85,6 +86,7 @@ struct ArachneTest : public ::testing::Test {
         Arachne::minNumCores = 1;
         Arachne::maxNumCores = 3;
         Arachne::disableLoadEstimation = true;
+        Arachne::coreArbiterSocketPath = TEST_SOCKET;
         ::arachne_init(NULL, NULL);
         // Artificially wake up all threads for testing purposes
         std::vector<uint32_t> coreRequest({3, 0, 0, 0, 0, 0, 0, 0});

--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -180,6 +180,7 @@ thread_local uint8_t DispatchTimeKeeper::numThreadsRan;
  */
 bool useCoreArbiter = true;
 
+std::string coreArbiterSocketPath = PROD_SOCKET;
 CoreArbiterClient* coreArbiter = NULL;
 
 /*
@@ -740,7 +741,8 @@ parseOptions(int* argcp, const char** argv) {
                             {"maxNumCores", 'm', true},
                             {"stackSize", 's', true},
                             {"enableArbiter", 'a', true},
-                            {"disableLoadEstimation", 'd', false}};
+                            {"disableLoadEstimation", 'd', false},
+                            {"coreArbiterSocketPath", 'p', true}};
     const int UNRECOGNIZED = ~0;
 
     int i = 1;
@@ -793,6 +795,8 @@ parseOptions(int* argcp, const char** argv) {
             case 'a':
                 useCoreArbiter = (0 != atoi(optionArgument));
                 break;
+            case 'p':
+                coreArbiterSocketPath = optionArgument;
             case UNRECOGNIZED:
                 i++;
         }
@@ -920,8 +924,9 @@ init(int* argcp, const char** argv) {
 
     parseOptions(argcp, argv);
 
-    coreArbiter = (useCoreArbiter) ? CoreArbiterClient::getInstance(TEST_SOCKET)
-                                   : ArbiterClientShim::getInstance();
+    coreArbiter = (useCoreArbiter)
+                      ? CoreArbiterClient::getInstance(coreArbiterSocketPath)
+                      : ArbiterClientShim::getInstance();
 
     if (corePolicy == NULL) {
         corePolicy = new CorePolicy();

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -37,8 +37,11 @@
 namespace Arachne {
 
 // Current location of CoreArbiter testsocket and testmem
-#define TEST_SOCKET "/tmp/CoreArbiter/testsocket"
-#define TEST_MEM "/tmp/CoreArbiter/testmem"
+#define TEST_SOCKET "/tmp/CoreArbiter_ArachneTest/testsocket"
+#define TEST_MEM "/tmp/CoreArbiter_ArachneTest/testmem"
+
+// The standard path where the real CoreArbiterServer will run from.
+#define PROD_SOCKET "/tmp/CoreArbiter/testsocket"
 
 // A macro to disallow the copy constructor and operator= functions
 #ifndef DISALLOW_COPY_AND_ASSIGN

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -38,6 +38,7 @@ extern std::atomic<uint32_t> numActiveCores;
 extern volatile uint32_t minNumCores;
 extern int* virtualCoreTable;
 
+extern std::string coreArbiterSocketPath;
 extern CoreArbiterClient* coreArbiter;
 
 static void limitedTimeWait(std::function<bool()> condition,
@@ -83,6 +84,7 @@ struct ArachneTest : public ::testing::Test {
         Arachne::minNumCores = 1;
         Arachne::maxNumCores = 3;
         Arachne::disableLoadEstimation = true;
+        Arachne::coreArbiterSocketPath = TEST_SOCKET;
         Arachne::init();
         // Articially wake up all threads for testing purposes
         std::vector<uint32_t> coreRequest({3, 0, 0, 0, 0, 0, 0, 0});

--- a/src/CorePolicyTest.cc
+++ b/src/CorePolicyTest.cc
@@ -39,6 +39,7 @@ extern std::atomic<uint32_t> numActiveCores;
 extern volatile uint32_t minNumCores;
 extern int* virtualCoreTable;
 
+extern std::string coreArbiterSocketPath;
 extern CoreArbiterClient* coreArbiter;
 
 static void limitedTimeWait(std::function<bool()> condition,
@@ -84,6 +85,7 @@ struct ArachneTest : public ::testing::Test {
         Arachne::minNumCores = 1;
         Arachne::maxNumCores = 3;
         Arachne::disableLoadEstimation = true;
+        Arachne::coreArbiterSocketPath = TEST_SOCKET;
         Arachne::init();
         // Artificially wake up all threads for testing purposes
         std::vector<uint32_t> coreRequest({3, 0, 0, 0, 0, 0, 0, 0});


### PR DESCRIPTION
This change allows Arachne tests (which do not require sudo) to avoid
conflicting with the paths used by CoreArbiter tests (which do require sudo).
After this change, users no longer need to manually delete directories after
running CoreArbiter unit tests.