### PR TITLE
Add initial CoreManager and CreateThreadWithClass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CHECK_TARGET=$$(find $(SRC_DIR) $(WRAPPER_DIR) '(' -name '*.h' -or -name '*.cc' 
 endif
 
 # Conversion to fully qualified names
-OBJECT_NAMES := Arachne.o Logger.o PerfStats.o CorePolicy.o arachne_wrapper.o
+OBJECT_NAMES := Arachne.o Logger.o PerfStats.o DefaultCoreManager.o arachne_wrapper.o
 
 OBJECTS = $(patsubst %,$(OBJECT_DIR)/%,$(OBJECT_NAMES))
 HEADERS= $(shell find $(SRC_DIR) $(WRAPPER_DIR) -name '*.h')
@@ -80,9 +80,9 @@ CTEST_LIBS=-Lobj/ -lArachne
 INCLUDE+=-I${GTEST_DIR}/include
 COREARBITER_BIN=$(COREARBITER)/bin/coreArbiterServer
 
-test: $(OBJECT_DIR)/ArachneTest $(OBJECT_DIR)/CorePolicyTest $(OBJECT_DIR)/arachne_wrapper_test
+test: $(OBJECT_DIR)/ArachneTest $(OBJECT_DIR)/DefaultCoreManagerTest $(OBJECT_DIR)/arachne_wrapper_test
 	$(OBJECT_DIR)/ArachneTest
-	$(OBJECT_DIR)/CorePolicyTest
+	$(OBJECT_DIR)/DefaultCoreManagerTest
 	$(OBJECT_DIR)/arachne_wrapper_test
 
 ctest: $(OBJECT_DIR)/arachne_wrapper_ctest
@@ -97,7 +97,7 @@ $(OBJECT_DIR)/arachne_wrapper_test: $(OBJECT_DIR)/arachne_wrapper_test.o $(OBJEC
 $(OBJECT_DIR)/ArachneTest: $(OBJECT_DIR)/ArachneTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libArachne.a
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
 
-$(OBJECT_DIR)/CorePolicyTest: $(OBJECT_DIR)/CorePolicyTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libArachne.a
+$(OBJECT_DIR)/DefaultCoreManagerTest: $(OBJECT_DIR)/DefaultCoreManagerTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libArachne.a
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
 
 $(OBJECT_DIR)/libgtest.a:

--- a/Makefile
+++ b/Makefile
@@ -75,15 +75,17 @@ check:
 ################################################################################
 # Test Targets
 GTEST_DIR=../googletest/googletest
+GMOCK_DIR=../googletest/googlemock
 TEST_LIBS=-Lobj/ -lArachne $(OBJECT_DIR)/libgtest.a
 CTEST_LIBS=-Lobj/ -lArachne
-INCLUDE+=-I${GTEST_DIR}/include
+INCLUDE+=-I${GTEST_DIR}/include -I${GMOCK_DIR}/include
 COREARBITER_BIN=$(COREARBITER)/bin/coreArbiterServer
 
-test: $(OBJECT_DIR)/ArachneTest $(OBJECT_DIR)/DefaultCoreManagerTest $(OBJECT_DIR)/arachne_wrapper_test
+test: $(OBJECT_DIR)/ArachneTest $(OBJECT_DIR)/CoreManagerTest $(OBJECT_DIR)/DefaultCoreManagerTest $(OBJECT_DIR)/arachne_wrapper_test
 	$(OBJECT_DIR)/ArachneTest
 	$(OBJECT_DIR)/DefaultCoreManagerTest
 	$(OBJECT_DIR)/arachne_wrapper_test
+	$(OBJECT_DIR)/CoreManagerTest
 
 ctest: $(OBJECT_DIR)/arachne_wrapper_ctest
 	$(OBJECT_DIR)/arachne_wrapper_ctest
@@ -98,6 +100,9 @@ $(OBJECT_DIR)/ArachneTest: $(OBJECT_DIR)/ArachneTest.o $(OBJECT_DIR)/libgtest.a 
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
 
 $(OBJECT_DIR)/DefaultCoreManagerTest: $(OBJECT_DIR)/DefaultCoreManagerTest.o $(OBJECT_DIR)/libgtest.a $(OBJECT_DIR)/libArachne.a
+	$(CXX) $(INCLUDE) $(CXXFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
+
+$(OBJECT_DIR)/CoreManagerTest: $(OBJECT_DIR)/CoreManagerTest.o $(OBJECT_DIR)/libgtest.a
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $< $(GTEST_DIR)/src/gtest_main.cc $(TEST_LIBS) $(LIBS)  -o $@
 
 $(OBJECT_DIR)/libgtest.a:

--- a/cwrapper/arachne_wrapper.cc
+++ b/cwrapper/arachne_wrapper.cc
@@ -61,6 +61,23 @@ arachne_wait_termination() {
 }
 
 /**
+ * This function is the wrapper for Arachne::createThreadWithClass.
+ */
+int
+arachne_thread_create_with_class(arachne_thread_id* id, void* (*func)(void*),
+                                 void* arg, int thread_class) {
+    Arachne::ThreadId tid =
+        Arachne::createThreadWithClass(thread_class, func, arg);
+    if (tid == Arachne::NullThread) {
+        return -1;
+    }
+
+    id->context = reinterpret_cast<arachne_thread_context*>(tid.context);
+    id->generation = tid.generation;
+    return 0;
+}
+
+/**
  * This function is the wrapper for Arachne::createThread.
  * We have changed the interface due to no template support in C.
  *
@@ -77,14 +94,7 @@ arachne_wait_termination() {
  */
 int
 arachne_thread_create(arachne_thread_id* id, void* (*func)(void*), void* arg) {
-    Arachne::ThreadId tid = Arachne::createThread(func, arg);
-    if (tid == Arachne::NullThread) {
-        return -1;
-    }
-
-    id->context = reinterpret_cast<arachne_thread_context*>(tid.context);
-    id->generation = tid.generation;
-    return 0;
+    return arachne_thread_create_with_class(id, func, arg, 0);
 }
 
 /**
@@ -106,14 +116,6 @@ arachne_thread_join(arachne_thread_id* id) {
 void
 arachne_thread_yield() {
     Arachne::yield();
-}
-
-/**
- * This function is the wrapper for Arachne::makeExclusiveOnCore.
- */
-bool
-arachne_thread_exclusive_core(bool scale_down) {
-    return Arachne::makeExclusiveOnCore(scale_down);
 }
 
 #ifdef __cplusplus

--- a/cwrapper/arachne_wrapper.cc
+++ b/cwrapper/arachne_wrapper.cc
@@ -62,6 +62,11 @@ arachne_wait_termination() {
 
 /**
  * This function is the wrapper for Arachne::createThreadWithClass.
+ * Under Arachne's default core manager, the following thread classes are
+ * available.
+ *
+ *    Class 0: Normal thread creation
+ *    Class 1: Exclusive thread creation
  */
 int
 arachne_thread_create_with_class(arachne_thread_id* id, void* (*func)(void*),

--- a/cwrapper/arachne_wrapper.h
+++ b/cwrapper/arachne_wrapper.h
@@ -53,7 +53,9 @@ int arachne_thread_create(arachne_thread_id* id, void* (*func)(void*),
                           void* arg);
 void arachne_thread_join(arachne_thread_id* id);
 void arachne_thread_yield();
-bool arachne_thread_exclusive_core(bool scale_down);
+int arachne_thread_create_with_class(arachne_thread_id* id,
+                                     void* (*func)(void*), void* arg,
+                                     int thread_class);
 
 #ifdef __cplusplus
 }

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -619,6 +619,8 @@ createThreadWithClass(int threadClass, _Callable&& __f, _Args&&... __args) {
     // the one with the fewest Arachne threads.
     uint32_t kId;
     CoreList* coreList = coreManager->getCores(threadClass);
+    if (coreList == NULL)
+        return Arachne::NullThread;
     uint32_t index1 = static_cast<uint32_t>(random()) % coreList->size();
     uint32_t index2 = static_cast<uint32_t>(random()) % coreList->size();
     while (index2 == index1 && coreList->size() > 1)

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -371,8 +371,8 @@ TEST_F(ArachneTest, createThread_pickLeastLoaded) {
     mockRandomValues.push_back(0);
     mockRandomValues.push_back(1);
     createThread(clearFlag);
-    int core0 = coreManager->getCores(0)[0];
-    int core1 = coreManager->getCores(0)[1];
+    int core0 = coreManager->getCores(0)->get(0);
+    int core1 = coreManager->getCores(0)->get(1);
     EXPECT_EQ(1U, Arachne::occupiedAndCount[core1]->load().numOccupied);
     EXPECT_EQ(1U, Arachne::occupiedAndCount[core1]->load().occupied);
     threadCreationIndicator = 1;
@@ -841,11 +841,14 @@ extern volatile bool coreChangeActive;
 bool
 canThreadBeCreatedOnCore(int threadClass, CoreManager* coreManager,
                          int coreId) {
-    CoreListView entry = coreManager->getCores(threadClass);
-    for (uint32_t i = 0; i < entry.size(); i++) {
-        if (entry[i] == coreId)
+    CoreList* coreList = coreManager->getCores(threadClass);
+    for (uint32_t i = 0; i < coreList->size(); i++) {
+        if (coreList->get(i) == coreId) {
+            coreList->free();
             return true;
+        }
     }
+    coreList->free();
     return false;
 }
 

--- a/src/CoreLoadEstimator.h
+++ b/src/CoreLoadEstimator.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef CORELOADESTIMATOR_H_
+#define CORELOADESTIMATOR_H_
+
+namespace Arachne {
+
+/**
+ * Objects of this class offer recommendations about whether core count should
+ * increase, decrease, or stay the same based on the current load factor and
+ * utilization of cores.
+ */
+class CoreLoadEstimator {
+  public:
+    /**
+     * Returns -1,0,1 to suggest whether the core count should decrease,
+     * stay the same, or increase respectively.
+     */
+    int estimate(int currentNumCores);
+
+    /**
+     * Clear any historical load metrics; the next call to `estimate` will
+     * return 0.
+     */
+    int reset();
+};
+
+}  // namespace Arachne
+#endif  // DEFAULTCOREMANAGER_H_

--- a/src/CoreManager.h
+++ b/src/CoreManager.h
@@ -39,22 +39,29 @@ struct CoreList {
      */
     ~CoreList() {
         if (cores != NULL)
-            delete cores;
+            delete[] cores;
     }
     CoreList& operator=(CoreList&& other) {
         numFilled = other.numFilled;
         capacity = other.capacity;
+        mustFree = other.mustFree;
         cores = other.cores;
         other.cores = NULL;
+        other.capacity = 0;
+        other.numFilled = 0;
+        other.mustFree = false;
         return *this;
     }
+    CoreList(CoreList& other) { *this = other; }
     CoreList& operator=(const CoreList& other) {
         numFilled = other.numFilled;
         capacity = other.capacity;
+        mustFree = other.mustFree;
         cores = new int[capacity];
         memcpy(cores, other.cores, numFilled * sizeof(cores[0]));
         return *this;
     }
+    CoreList(CoreList&& other) { *this = std::move(other); }
     uint32_t size() { return numFilled; }
     void add(int coreId) {
         this->cores[numFilled] = coreId;

--- a/src/CoreManager.h
+++ b/src/CoreManager.h
@@ -1,0 +1,161 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef COREMANAGER_H_
+#define COREMANAGER_H_
+
+#include <string.h>
+#include <atomic>
+
+namespace Arachne {
+/*
+ * An unordered list of cores.
+ */
+struct CoreList {
+    explicit CoreList(int capacity)
+        : capacity(static_cast<uint16_t>(capacity)) {
+        cores = new int[capacity];
+        numFilled = 0;
+    }
+    ~CoreList() {
+        if (cores != NULL)
+            delete cores;
+    }
+    CoreList& operator=(CoreList&& other) {
+        numFilled = other.numFilled;
+        capacity = other.capacity;
+        cores = other.cores;
+        other.cores = NULL;
+        return *this;
+    }
+    CoreList& operator=(const CoreList& other) {
+        numFilled = other.numFilled;
+        capacity = other.capacity;
+        cores = new int[capacity];
+        memcpy(cores, other.cores, numFilled * sizeof(cores[0]));
+        return *this;
+    }
+    uint32_t size() { return numFilled; }
+    void add(int coreId) {
+        this->cores[numFilled] = coreId;
+        this->numFilled++;
+    }
+    void remove(int index) {
+        memmove(cores + index, cores + index + 1,
+                (numFilled - index - 1) * sizeof(int));
+        numFilled--;
+    }
+    int& operator[](std::size_t index) { return cores[index]; }
+
+    /* The number of cores in the list */
+    uint16_t numFilled;
+    uint16_t capacity;
+
+    /*
+     * An array containing IDs for cores in this list.
+     */
+    int* cores;
+};
+
+/*
+ * An object which can be used as a CoreList by the Arachne runtime. It
+ * exists to facilitate memory management, allowing CoreManagers to return
+ * either a pointer to a CoreList or a CoreList.
+ */
+struct CoreListView {
+    explicit CoreListView(int capacity)
+        : isPointer(false), coreList(capacity) {}
+    explicit CoreListView(CoreList* list)
+        : isPointer(true), coreListPointer(list) {}
+    ~CoreListView() {}
+
+    // Both copy and move operators are defined because Arachne's use of
+    // std::bind requires at least one copy.
+    // If Arachne ever removes its dependency on std::bind, it's possible that
+    // the copy assignment and constructor operators can be removed.
+    CoreListView(CoreListView&& other) { *this = std::move(other); }
+    CoreListView(const CoreListView& other) { *this = other; }
+    CoreListView& operator=(CoreListView&& other) {
+        isPointer = other.isPointer;
+        if (isPointer) {
+            coreListPointer = other.coreListPointer;
+        } else {
+            coreList = std::move(other.coreList);
+        }
+        return *this;
+    }
+    CoreListView& operator=(const CoreListView& other) {
+        isPointer = other.isPointer;
+        if (isPointer) {
+            coreListPointer = other.coreListPointer;
+        } else {
+            coreList = other.coreList;
+        }
+        return *this;
+    }
+
+    uint32_t size() {
+        return isPointer ? coreListPointer->size() : coreList.size();
+    }
+    int& operator[](std::size_t index) {
+        return isPointer ? (*coreListPointer)[index] : coreList[index];
+    }
+    void add(int coreId) {
+        if (isPointer)
+            coreListPointer->add(coreId);
+        else
+            coreList.add(coreId);
+    }
+
+    bool isPointer;
+    /*
+     * An array containing IDs for cores in this list.
+     */
+    union {
+        CoreList* coreListPointer;
+        CoreList coreList;
+    };
+};
+
+/**
+ * Implementors of this interface specify the allocation and use of cores in
+ * Arachne.
+ */
+class CoreManager {
+  public:
+    /**
+     * Invoked by an Arachne kernel thread after it wakes up on a dedicated
+     * core and sets up state to run the Arachne scheduler.
+     */
+    virtual void coreAvailable(int myCoreId) = 0;
+
+    /**
+     * Invoked by Arachne when any core detects a core release request from
+     * the Core Arbiter. It is responsible for eventually scheduling
+     * releaseCore() onto the core most recently given by the CoreArbiter.
+     */
+    virtual void coreUnavailable() = 0;
+
+    /**
+     * Invoked by Arachne::createThread to get cores available for a particular
+     * threadClass.
+     */
+    virtual CoreListView getCores(int threadClass) = 0;
+
+    virtual ~CoreManager() {}
+};
+
+}  // namespace Arachne
+#endif  // COREMANAGER_H_

--- a/src/CoreManagerTest.cc
+++ b/src/CoreManagerTest.cc
@@ -1,0 +1,68 @@
+/* Copyright (c) 2015-2016 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "CoreManager.h"
+
+namespace Arachne {
+
+using ::testing::Eq;
+
+TEST(CoreManagerTest, CoreList_addRemove) {
+    CoreList list(8);
+    EXPECT_THAT(list.size(), Eq(0U));
+    list.add(1);
+    EXPECT_THAT(list.size(), Eq(1U));
+    EXPECT_THAT(list[0], Eq(1));
+    list.add(8);
+    EXPECT_THAT(list.size(), Eq(2U));
+    EXPECT_THAT(list[1], Eq(8));
+    list.remove(0);
+    EXPECT_THAT(list.size(), Eq(1U));
+    EXPECT_THAT(list[0], Eq(8));
+}
+
+TEST(CoreManagerTest, CoreList_copy) {
+    CoreList list(8, /*mustFree=*/true);
+    list.add(1);
+    list.add(8);
+    CoreList copy(list);
+    EXPECT_THAT(copy.capacity, Eq(list.capacity));
+    EXPECT_THAT(copy.mustFree, Eq(list.mustFree));
+    EXPECT_THAT(copy.size(), Eq(list.size()));
+    EXPECT_THAT(copy[0], Eq(list[0]));
+    EXPECT_THAT(copy[1], Eq(list[1]));
+}
+
+TEST(CoreManagerTest, CoreList_move) {
+    CoreList list(8, /*mustFree=*/true);
+    list.add(1);
+    list.add(8);
+    CoreList moveTarget(std::move(list));
+    EXPECT_THAT(moveTarget.capacity, Eq(8));
+    EXPECT_THAT(moveTarget.mustFree, Eq(true));
+    EXPECT_THAT(moveTarget.size(), Eq(2U));
+    EXPECT_THAT(moveTarget[0], Eq(1));
+    EXPECT_THAT(moveTarget[1], Eq(8));
+
+    EXPECT_THAT(list.capacity, Eq(0));
+    EXPECT_THAT(list.mustFree, Eq(false));
+    EXPECT_THAT(list.size(), Eq(0U));
+    EXPECT_TRUE(list.cores == NULL);
+}
+
+}  // namespace Arachne

--- a/src/DefaultCoreManager.cc
+++ b/src/DefaultCoreManager.cc
@@ -67,7 +67,7 @@ DefaultCoreManager::getCores(int threadClass) {
             retVal->add(coreId);
             return retVal;
     }
-    return new CoreList(0, /*mustFree=*/true);
+    return NULL;
 }
 
 /**

--- a/src/DefaultCoreManager.cc
+++ b/src/DefaultCoreManager.cc
@@ -1,0 +1,119 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "DefaultCoreManager.h"
+#include <atomic>
+#include "Arachne.h"
+
+namespace Arachne {
+
+void removeThreadsFromCore(CoreListView outputCores);
+
+DefaultCoreManager::DefaultCoreManager(int minNumCores, int maxNumCores)
+    : minNumCores(minNumCores),
+      maxNumCores(maxNumCores),
+      loadEstimator(),
+      lock(false),
+      sharedCores(maxNumCores),
+      exclusiveCores(maxNumCores) {}
+
+void
+DefaultCoreManager::coreAvailable(int myCoreId) {
+    Lock guard(lock);
+    sharedCores.add(myCoreId);
+}
+
+/**
+ * Prevent further creations on and remove all threads from the most
+ * recently acquired core, and schedule releaseCore() on it. Log an error
+ * and abort the process if loss of a core results in no cores available
+ * for general scheduling.
+ */
+void
+DefaultCoreManager::coreUnavailable() {
+    Lock guard(lock);
+    // TODO(hq6): Implement this function
+}
+
+/**
+ * Invoked by Arachne::createThread to get cores available for scheduling of
+ * short-lived tasks. Returns NULL if an invalid threadClass is passed in.
+ */
+CoreListView
+DefaultCoreManager::getCores(int threadClass) {
+    switch (threadClass) {
+        case DEFAULT:
+            return CoreListView(&sharedCores);
+        case EXCLUSIVE:
+            int coreId = getExclusiveCore();
+            if (coreId < 0)
+                break;
+            CoreListView retVal(1);
+            retVal.add(coreId);
+            return retVal;
+    }
+    return CoreListView(0);
+}
+
+/**
+ * After this function returns, no load estimations will happen in the
+ * future.
+ */
+void
+DefaultCoreManager::disableLoadEstimation() {
+    // TODO(hq6): Implement this function
+}
+
+int
+DefaultCoreManager::getExclusiveCore() {
+    Lock guard(lock);
+    // Look for an existing idle exclusive core
+    for (uint32_t i = 0; i < exclusiveCores.size(); i++) {
+        if (occupiedAndCount[exclusiveCores[i]]->load().occupied == 0) {
+            // Enable scheduling on this core again
+            *occupiedAndCount[exclusiveCores[i]] = {0, 0};
+            return exclusiveCores[i];
+        }
+    }
+    // Failed to find one; make one instead from the shared cores.
+    // Take the oldest core to be an exclusive core, so it is relinquished last.
+    // No cores available, return failure.
+    if (sharedCores.size() == 0) {
+        return -1;
+    }
+    int newExclusiveCore = sharedCores[0];
+    exclusiveCores.add(newExclusiveCore);
+    sharedCores.remove(0);
+
+    ThreadId migrationThread = createThreadOnCore(
+        newExclusiveCore, removeThreadsFromCore, CoreListView(&sharedCores));
+    // The current thread is a non-Arachne thread.
+    if (core.kernelThreadId == -1) {
+        // Polling for completion is a short-term hack until we figure out a
+        // good story for joining Arachne threads from non-Arachne threads.
+        while (Arachne::occupiedAndCount[newExclusiveCore]->load().occupied)
+            usleep(10);
+    } else {
+        Arachne::join(migrationThread);
+    }
+
+    // Prepare this core for scheduling exclusively.
+    // By setting numOccupied to one less than the maximium number of threads
+    // per core, we ensure that only one thread gets scheduled onto this core.
+    *occupiedAndCount[newExclusiveCore] = {0, maxThreadsPerCore - 1};
+    return newExclusiveCore;
+}
+
+}  // namespace Arachne

--- a/src/DefaultCoreManager.cc
+++ b/src/DefaultCoreManager.cc
@@ -29,6 +29,9 @@ DefaultCoreManager::DefaultCoreManager(int minNumCores, int maxNumCores)
       sharedCores(maxNumCores),
       exclusiveCores(maxNumCores) {}
 
+/**
+ * Add the given core to the pool of threads for general scheduling.
+ */
 void
 DefaultCoreManager::coreAvailable(int myCoreId) {
     Lock guard(lock);
@@ -68,14 +71,17 @@ DefaultCoreManager::getCores(int threadClass) {
 }
 
 /**
- * After this function returns, no load estimations will happen in the
- * future.
+ * After this function returns, no load estimations that have already begun
+ * will complete, but no future load estimations will occur.
  */
 void
 DefaultCoreManager::disableLoadEstimation() {
     // TODO(hq6): Implement this function
 }
 
+/**
+ * Find or allocate a core for exclusive use by a thread.
+ */
 int
 DefaultCoreManager::getExclusiveCore() {
     Lock guard(lock);

--- a/src/DefaultCoreManager.h
+++ b/src/DefaultCoreManager.h
@@ -49,7 +49,7 @@ class DefaultCoreManager : public CoreManager {
      * Invoked by Arachne to get cores available for scheduling a particular
      * threadClass.
      */
-    virtual CoreListView getCores(int threadClass);
+    virtual CoreList* getCores(int threadClass);
 
     /**
      * After this function returns, no load estimations that have already begun

--- a/src/DefaultCoreManager.h
+++ b/src/DefaultCoreManager.h
@@ -1,0 +1,102 @@
+/* Copyright (c) 2017 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef DEFAULTCOREMANAGER_H_
+#define DEFAULTCOREMANAGER_H_
+
+#include <mutex>
+#include "CoreLoadEstimator.h"
+#include "CoreManager.h"
+#include "SpinLock.h"
+
+namespace Arachne {
+
+/**
+ * Arachne's default CoreManager makes all cores available for general
+ * scheduling unless the application invokes createExclusiveThread; each call
+ * to createExclusiveThread will remove one core from the general scheduling
+ * pool.
+ */
+class DefaultCoreManager : public CoreManager {
+  public:
+    DefaultCoreManager(int minNumCores, int maxNumCores);
+    /**
+     * Add the given core to the pool of threads for general scheduling.
+     */
+    virtual void coreAvailable(int myCoreId);
+
+    /**
+     * Prevent further creations on and remove all threads from the most
+     * recently acquired core, and schedule releaseCore() on it. Log an error
+     * and abort the process if loss of a core results in no cores available
+     * for general scheduling.
+     */
+    virtual void coreUnavailable();
+
+    /**
+     * Invoked by Arachne to get cores available for scheduling a particular
+     * threadClass.
+     */
+    virtual CoreListView getCores(int threadClass);
+
+    /**
+     * After this function returns, no load estimations that have already begun
+     * will complete, but no future load estimations will occur.
+     */
+    void disableLoadEstimation();
+
+    /**
+     * Limit the thread classes that the default core manager supports.
+     */
+    enum ThreadClass { DEFAULT = 0, EXCLUSIVE = 1 };
+
+  private:
+    /**
+     * Find or allocate a core for exclusive use by a thread.
+     */
+    int getExclusiveCore();
+    /**
+     * The minimum number of cores that the application needs to run
+     * effectively.
+     */
+    const int minNumCores;
+    /**
+     * The maximum number of cores that Arachne will use.
+     */
+    const int maxNumCores;
+    /**
+     * Used to determine whether the system needs more cores or fewer cores.
+     */
+    CoreLoadEstimator loadEstimator;
+
+    typedef std::lock_guard<SpinLock> Lock;
+
+    /**
+     * Protect the data structures below for writes.
+     */
+    SpinLock lock;
+
+    /**
+     * Cores that are available for general scheduling.
+     */
+    CoreList sharedCores;
+
+    /**
+     * Cores that are currently hosting exclusive threads.
+     */
+    CoreList exclusiveCores;
+};
+}  // namespace Arachne
+#endif  // DEFAULTCOREMANAGER_H_

--- a/src/DefaultCoreManager.h
+++ b/src/DefaultCoreManager.h
@@ -32,29 +32,9 @@ namespace Arachne {
 class DefaultCoreManager : public CoreManager {
   public:
     DefaultCoreManager(int minNumCores, int maxNumCores);
-    /**
-     * Add the given core to the pool of threads for general scheduling.
-     */
     virtual void coreAvailable(int myCoreId);
-
-    /**
-     * Prevent further creations on and remove all threads from the most
-     * recently acquired core, and schedule releaseCore() on it. Log an error
-     * and abort the process if loss of a core results in no cores available
-     * for general scheduling.
-     */
     virtual void coreUnavailable();
-
-    /**
-     * Invoked by Arachne to get cores available for scheduling a particular
-     * threadClass.
-     */
     virtual CoreList* getCores(int threadClass);
-
-    /**
-     * After this function returns, no load estimations that have already begun
-     * will complete, but no future load estimations will occur.
-     */
     void disableLoadEstimation();
 
     /**
@@ -63,9 +43,6 @@ class DefaultCoreManager : public CoreManager {
     enum ThreadClass { DEFAULT = 0, EXCLUSIVE = 1 };
 
   private:
-    /**
-     * Find or allocate a core for exclusive use by a thread.
-     */
     int getExclusiveCore();
     /**
      * The minimum number of cores that the application needs to run

--- a/src/DefaultCoreManagerTest.cc
+++ b/src/DefaultCoreManagerTest.cc
@@ -139,21 +139,23 @@ TEST_F(DefaultCoreManagerTest, DefaultCoreManager_coreAvailable) {
 
 TEST_F(DefaultCoreManagerTest, DefaultCoreManager_getCoresDefault) {
     DefaultCoreManager coreManager(1, 4);
-    CoreListView entry = coreManager.getCores(DefaultCoreManager::DEFAULT);
-    EXPECT_EQ(entry.size(), 0U);
+    CoreList* coreList = coreManager.getCores(DefaultCoreManager::DEFAULT);
+    EXPECT_EQ(coreList->size(), 0U);
     coreManager.coreAvailable(5);
-    EXPECT_EQ(entry.size(), 1U);
+    EXPECT_EQ(coreList->size(), 1U);
     coreManager.coreAvailable(7);
-    EXPECT_EQ(entry.size(), 2U);
+    EXPECT_EQ(coreList->size(), 2U);
+    coreList->free();
 }
 
 TEST_F(DefaultCoreManagerTest, DefaultCoreManager_getCoresExclusive) {
     DefaultCoreManager* coreManager =
         reinterpret_cast<DefaultCoreManager*>(Arachne::getCoreManagerForTest());
-    CoreListView entry = coreManager->getCores(DefaultCoreManager::EXCLUSIVE);
-    EXPECT_EQ(entry.size(), 1U);
-    entry = coreManager->getCores(DefaultCoreManager::EXCLUSIVE);
-    EXPECT_EQ(entry.size(), 1U);
+    CoreList* coreList = coreManager->getCores(DefaultCoreManager::EXCLUSIVE);
+    EXPECT_EQ(coreList->size(), 1U);
+    coreList = coreManager->getCores(DefaultCoreManager::EXCLUSIVE);
+    EXPECT_EQ(coreList->size(), 1U);
+    coreList->free();
 }
 
 }  // namespace Arachne


### PR DESCRIPTION
This PR combines several closely related changes.
     
   - Introduce CoreManager as an interface.
   - Implement DefaultCoreManager and related tests as an implementation which
     supports normal and exclusive threads.
   - Remove virtualCoreTable from Arachne.
