### PR TITLE
Add function to get thread local thread id

### DIFF
--- a/cwrapper/arachne_wrapper.cc
+++ b/cwrapper/arachne_wrapper.cc
@@ -116,6 +116,13 @@ arachne_thread_exclusive_core(bool scale_down) {
     return Arachne::makeExclusiveOnCore(scale_down);
 }
 
+/**
+ * This function is used to get thread local variable Arachne::core.kernelThreadId
+ */
+int arachne_thread_getid() {
+    return Arachne::core.kernelThreadId;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/cwrapper/arachne_wrapper.h
+++ b/cwrapper/arachne_wrapper.h
@@ -54,6 +54,7 @@ int arachne_thread_create(arachne_thread_id* id, void* (*func)(void*),
 void arachne_thread_join(arachne_thread_id* id);
 void arachne_thread_yield();
 bool arachne_thread_exclusive_core(bool scale_down);
+int arachne_thread_getid();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently it returns virtual core/thread id. But Arachne will eventually use
physical thread id.