### PR TITLE
Fix the bug when user creates n exclusive threads on n cores

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -1374,9 +1374,15 @@ removeThreadsFromCore(CoreList* outputCores) {
             continue;
         }
         // Choose a victim core that we will pawn our work on.
-        nextMigrationTarget = (nextMigrationTarget + 1) % outputCores->size();
-        int coreId = outputCores->get(nextMigrationTarget);
         if ((blockedOccupiedAndCount.occupied >> i) & 1) {
+            if (outputCores->size() == 0) {
+                ARACHNE_LOG(ERROR, "No available cores to migrate threads to.");
+                exit(1);
+            }
+            nextMigrationTarget =
+                (nextMigrationTarget + 1) % outputCores->size();
+            int coreId = outputCores->get(nextMigrationTarget);
+
             bool success = false;
             uint8_t index;
             do {


### PR DESCRIPTION
The bug is that when a user tries to create n exclusive threads on n cores,
Arachne would crash due to divide by zero even we have nothing to migrate.
That's because we have no available cores to migrate. So we should only try to
find a targate core iff there is a slot (exclude itself) needs to be
migrated.