### PR TITLE
Set the zeroCoreUtilization threshold to a larger value

### DIFF
--- a/src/CoreLoadEstimator.h
+++ b/src/CoreLoadEstimator.h
@@ -79,7 +79,7 @@ class CoreLoadEstimator {
     /*
      * Core utilizations below this threshold are considered effectively 0.
      */
-    double zeroCoreUtilizationThreshold = 1e-6;
+    double zeroCoreUtilizationThreshold = 1e-3;
 
     /*
      * Do not ramp down if the percentage of occupied threadContext slots is


### PR DESCRIPTION
Try to fix failing to ramp down issue. Since the estimator is running and
consuming CPU cycles, if the threshold is too low, it would prevent the number
of cores from ramping down.