### PR TITLE
Protect mockRandomValues using ARACHNE_TEST instead of TEST.

### DIFF
--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -409,7 +409,7 @@ extern std::vector<std::atomic<MaskAndCount>*> occupiedAndCount;
 
 extern std::vector<std::atomic<uint64_t>*> publicPriorityMasks;
 
-#ifdef TEST
+#ifdef ARACHNE_TEST
 extern std::deque<uint64_t> mockRandomValues;
 #endif
 
@@ -419,7 +419,7 @@ extern std::deque<uint64_t> mockRandomValues;
  */
 inline uint64_t
 random(void) {
-#ifdef TEST
+#ifdef ARACHNE_TEST
     if (!mockRandomValues.empty()) {
         uint64_t returnValue = mockRandomValues.front();
         mockRandomValues.pop_front();

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -18,7 +18,9 @@
 #include "gtest/gtest.h"
 
 #define private public
+#define ARACHNE_TEST
 #include "Arachne.h"
+#undef ARACHNE_TEST
 #include "CoreArbiter/ArbiterClientShim.h"
 #include "CoreArbiter/CoreArbiterClient.h"
 #include "CoreArbiter/CoreArbiterServer.h"


### PR DESCRIPTION
This mitigates a linker error when applications that define TEST for their own
reasons do not have a definition for mockRandomValues.