### PR TITLE
Change idleCore/unidleCore to have semaphore semantics

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -23,7 +23,6 @@
 
 #include "Arachne.h"
 #include "CoreArbiter/ArbiterClientShim.h"
-#include "CoreArbiter/Semaphore.h"
 
 namespace Arachne {
 
@@ -164,9 +163,6 @@ std::vector<uint64_t*> lastTotalCollectionTime;
  * Values pointed to must be in separate cache lines for high performance.
  */
 std::vector<std::atomic<uint64_t>*> publicPriorityMasks;
-
-/* Which cores are idled? */
-std::atomic<bool>* coreIdle;
 
 /**
  * An array of semaphores cores can park on to idle themselves.
@@ -619,7 +615,7 @@ dispatch() {
     // from TLS after switching back to this context.
     ThreadContext* originalContext = core.loadedContext;
     if (unlikely(*reinterpret_cast<uint64_t*>(core.loadedContext->stack) !=
-        STACK_CANARY)) {
+                 STACK_CANARY)) {
         ARACHNE_LOG(ERROR,
                     "Stack overflow detected on %p. Canary = %lu."
                     " Aborting...\n",
@@ -882,7 +878,6 @@ waitForTermination() {
     kernelThreads.clear();
     kernelThreadStacks.clear();
 
-    delete[] coreIdle;
     allThreadContexts.clear();
     occupiedAndCount.clear();
     pinnedContexts.clear();
@@ -1140,10 +1135,8 @@ init(int* argcp, const char** argv) {
     pinnedContexts.resize(numHardwareCores);
     publicPriorityMasks.resize(numHardwareCores);
     allThreadContexts.resize(numHardwareCores);
-    coreIdle = new std::atomic<bool>[numHardwareCores];
     for (unsigned int i = 0; i < numHardwareCores; i++) {
         coreIdleSemaphores.push_back(new ::Semaphore);
-        coreIdle[i].store(false);
     }
 
     // Allocate space to store all the original kernel pointers
@@ -1716,18 +1709,16 @@ releaseCore() {
 
 /*
  * Put the core into the most quiescent possible state to minimize performance
- * interference with the hypertwin.
+ * interference with the hypertwin. Note that a core only becomes unidled if
+ * there have been at least as many calls to unidleCore  as there are idleCore.
  *
  * \param coreId
  *     The coreId of the core that will idle
  */
 void
 idleCore(int coreId) {
-    if (!coreIdle[coreId]) {
-        coreIdle[coreId] = true;
-        if (createThreadOnCore(coreId, idleCorePrivate) == NullThread) {
-            ARACHNE_LOG(ERROR, "Error creating idleCorePrivate thread\n");
-        }
+    if (createThreadOnCore(coreId, idleCorePrivate) == NullThread) {
+        ARACHNE_LOG(ERROR, "Error creating idleCorePrivate thread\n");
     }
 }
 
@@ -1742,11 +1733,11 @@ void
 idleCorePrivate() {
     // Our experiments show that Linux will put the core to sleep.
     coreIdleSemaphores[core.kernelThreadId]->wait();
-    coreIdle[core.kernelThreadId] = false;
 }
 
 /*
- * Unidle an idled core.  Do nothing to cores that are not currently idled.
+ * Unidle an core. If it was not idle, the next call to idleCore will not idle
+ * the core.
  *
  * \param coreId
  *     The coreId of the core that will be unidled.

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "Common.h"
+#include "CoreArbiter/Semaphore.h"
 #include "CorePolicy.h"
 #include "Logger.h"
 #include "PerfStats.h"
@@ -74,8 +75,7 @@ extern std::vector<ThreadContext**> allThreadContexts;
 
 extern CorePolicy* corePolicy;
 
-extern std::atomic<bool>* coreIdle;
-
+extern std::vector<::Semaphore*> coreIdleSemaphores;
 /*
  * True means that the Core Load Estimator will not run; used only in unit
  * tests.

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -981,18 +981,42 @@ TEST_F(ArachneTest, idleAndUnidle) {
     int core0 = corePolicy->getCores(0)[0];
     int core1 = corePolicy->getCores(0)[1];
     int core2 = corePolicy->getCores(0)[2];
+
     idleCore(core0);
     idleCore(core2);
-    limitedTimeWait([core2]() -> bool { return Arachne::coreIdle[core2]; });
-    EXPECT_TRUE(Arachne::coreIdle[core0]);
-    EXPECT_FALSE(Arachne::coreIdle[core1]);
-    EXPECT_TRUE(Arachne::coreIdle[core2]);
+
+    limitedTimeWait([core2]() -> bool {
+        return Arachne::coreIdleSemaphores[core2]->get_num_blocked_for_test() ==
+               1;
+    });
+    limitedTimeWait([core0]() -> bool {
+        return Arachne::coreIdleSemaphores[core0]->get_num_blocked_for_test() ==
+               1;
+    });
+
+    EXPECT_EQ(1,
+              Arachne::coreIdleSemaphores[core0]->get_num_blocked_for_test());
+    EXPECT_EQ(1,
+              Arachne::coreIdleSemaphores[core2]->get_num_blocked_for_test());
+
     unidleCore(core0);
     unidleCore(core2);
-    limitedTimeWait([core2]() -> bool { return !Arachne::coreIdle[core2]; });
-    EXPECT_FALSE(Arachne::coreIdle[core0]);
-    EXPECT_FALSE(Arachne::coreIdle[core1]);
-    EXPECT_FALSE(Arachne::coreIdle[core2]);
+
+    limitedTimeWait([core2]() -> bool {
+        return Arachne::coreIdleSemaphores[core2]->get_num_blocked_for_test() ==
+               0;
+    });
+    limitedTimeWait([core0]() -> bool {
+        return Arachne::coreIdleSemaphores[core0]->get_num_blocked_for_test() ==
+               0;
+    });
+
+    EXPECT_EQ(0,
+              Arachne::coreIdleSemaphores[core0]->get_num_blocked_for_test());
+    EXPECT_EQ(0,
+              Arachne::coreIdleSemaphores[core1]->get_num_blocked_for_test());
+    EXPECT_EQ(0,
+              Arachne::coreIdleSemaphores[core2]->get_num_blocked_for_test());
 }
 
 TEST_F(ArachneTest, nestedDispatchDetector) {


### PR DESCRIPTION
This commit removes the coreIdle array, and updates the semantics of idleCore
so that cores are idled when the number of idleCore calls exceeds the number of
unidleCore calls.

This PR addresses Issue #37.