### PR TITLE
Fix build failure due to falling through the default case in switch s…

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -935,6 +935,7 @@ parseOptions(int* argcp, const char** argv) {
                 break;
             case 'p':
                 coreArbiterSocketPath = optionArgument;
+                break;
             case UNRECOGNIZED:
                 i++;
         }


### PR DESCRIPTION
…tatement

error: this statement may fall through [-Werror=implicit-fallthrough=]
                 coreArbiterSocketPath = optionArgument;
                 ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
src/Arachne.cc:938:13: note: here
             case UNRECOGNIZED:
             ^~~~

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>