### PR TITLE
Update semantics around mustReleaseCore call.

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -58,6 +58,12 @@ struct Core {
     bool coreReadyForReturnToArbiter;
 
     /**
+     * True means that this core has already been scheduled for descheduling,
+     * after the core arbiter requested it back.
+     */
+    bool coreDeschedulingScheduled;
+
+    /**
      * This pointer allows fast access to the current kernel thread's
      * localThreadContexts without computing an offset from the global
      * allThreadContexts vector on each access.


### PR DESCRIPTION
 - Arachne will now assume mustReleaseCore returns on the core that the arbiter
   wants returned.
 - Arachne will now assume mustReleaseCore continues to return true on the
   requested core until it is returned.
 - Note that Arachne will log a warning but does not give back cores running
   exclusive threads.