### PR TITLE
Make PerfStats belong to a core instead of kernel thread.

### DIFF
--- a/cwrapper/arachne_wrapper.cc
+++ b/cwrapper/arachne_wrapper.cc
@@ -38,13 +38,6 @@ arachne_init(int* argcp, const char** argv) {
     // Capture the exception threw by Arachne::init
     try {
         Arachne::init(argcp, argv);
-
-        // Manually register thread local perf stats in C wrapper
-        // Reason: The main thread in C is controlled by C, and it doesn't run
-        // constructors for thread locals, which means the stats is not
-        // registered. This can cause incorrect aggregated data due to missing
-        // records in the main thread perf stats.
-        Arachne::PerfStats::registerStats(&Arachne::PerfStats::threadStats);
     } catch (const CoreArbiter::CoreArbiterClient::ClientException& e) {
         retval = -1;
         errno = ECONNREFUSED;  // Set errno to "Connection refused"
@@ -157,8 +150,7 @@ arachne_set_maxutil(double maxutil) {
  */
 void
 arachne_set_loadfactor(double loadfactor) {
-    reinterpret_cast<Arachne::DefaultCorePolicy*>(
-        Arachne::getCorePolicy())
+    reinterpret_cast<Arachne::DefaultCorePolicy*>(Arachne::getCorePolicy())
         ->getEstimator()
         ->setLoadFactorThreshold(loadfactor);
 }

--- a/cwrapper/arachne_wrapper_test.cc
+++ b/cwrapper/arachne_wrapper_test.cc
@@ -135,7 +135,6 @@ funcCreateTest(void* arg) {
 }
 
 TEST_F(ArachneTest, CWrapper_createThread) {
-    Arachne::testInit();
     arachne_thread_id threadId;
     unsigned arg = 0;
     int ret = ::arachne_thread_create(&threadId, funcCreateTest,
@@ -144,7 +143,6 @@ TEST_F(ArachneTest, CWrapper_createThread) {
 
     ::arachne_thread_join(&threadId);
     EXPECT_EQ(0xDEADBEEF, arg);
-    Arachne::testDestroy();
 }
 
 }  // namespace Arachne

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -87,10 +87,6 @@ extern bool disableLoadEstimation;
  * Most of the functions in this API, with the exception of Arachne::init(),
  * Arachne::shutDown(), Arachne::waitForTermination(), and
  * Arachne::createThread(), should only be called from within Arachne threads.
- *
- * In order to allow unit tests in non-Arachne threads to run,
- * Arachne::testInit() should be called once before all unit tests run, and
- * Arachne::testDestroy() should be called once after all unit tests finish.
  * @{
  */
 /**
@@ -149,8 +145,8 @@ void join(ThreadId id);
 ThreadId getThreadId();
 
 void setErrorStream(FILE* ptr);
-void testInit();
-void testDestroy();
+void mainThreadInit();
+void mainThreadDestroy();
 
 /**
  * A resource which blocks the current thread until it is available.
@@ -557,9 +553,9 @@ createThreadOnCore(uint32_t coreId, _Callable&& __f, _Args&&... __args) {
     uint32_t generation = allThreadContexts[coreId][index]->generation;
     threadContext->wakeupTimeInCycles = 0;
 
-    PerfStats::threadStats.numThreadsCreated++;
+    PerfStats::threadStats->numThreadsCreated++;
     if (failureCount)
-        PerfStats::threadStats.numContendedCreations++;
+        PerfStats::threadStats->numContendedCreations++;
 
     return ThreadId(threadContext, generation);
 }

--- a/src/ArachneTest.cc
+++ b/src/ArachneTest.cc
@@ -159,7 +159,7 @@ lockTaker(L* mutex) {
 }
 
 TEST_F(ArachneTest, SpinLock_lockUnlock) {
-    EXPECT_EQ(NULL, core.loadedContext);
+    ThreadContext* loadedContext = core.loadedContext;
     flag = 0;
     mutex.lock();
     EXPECT_NE(Arachne::NullThread,
@@ -169,7 +169,7 @@ TEST_F(ArachneTest, SpinLock_lockUnlock) {
     EXPECT_EQ(1, flag);
     usleep(1);
     EXPECT_EQ(1, flag);
-    EXPECT_EQ(NULL, mutex.owner);
+    EXPECT_EQ(loadedContext, mutex.owner);
     mutex.unlock();
     limitedTimeWait([]() -> bool { return !flag; });
     EXPECT_EQ(0, flag);
@@ -182,7 +182,6 @@ lockContender(SpinLock& lock) {
 }
 
 TEST_F(ArachneTest, SpinLock_printWarning) {
-    Arachne::testInit();
     char* str;
     size_t size;
     FILE* newStream = open_memstream(&str, &size);
@@ -194,7 +193,6 @@ TEST_F(ArachneTest, SpinLock_printWarning) {
     sleep(1E9 + 5000);
     lock.unlock();
     join(contender);
-    Arachne::testDestroy();
 
     fflush(newStream);
     setErrorStream(stderr);
@@ -826,7 +824,6 @@ waiter() {
 }
 
 TEST_F(ArachneTest, ConditionVariable_notifyOne) {
-    Arachne::testInit();
     numWaitedOn = 0;
     int coreId = corePolicy->getCores(0)[0];
     createThreadOnCore(coreId, waiter);
@@ -846,7 +843,6 @@ TEST_F(ArachneTest, ConditionVariable_notifyOne) {
     mutex.unlock();
     limitedTimeWait([]() -> bool { return numWaitedOn != 1; });
     EXPECT_EQ(0, numWaitedOn);
-    Arachne::testDestroy();
 }
 
 TEST_F(ArachneTest, ConditionVariable_notifyAll) {

--- a/src/CoreLoadEstimator.cc
+++ b/src/CoreLoadEstimator.cc
@@ -25,18 +25,22 @@ CoreLoadEstimator::~CoreLoadEstimator() {}
 /**
  * Returns -1,0,1 to suggest whether the core count should decrease,
  * stay the same, or increase respectively.
+ *
+ * \param coreList
+ *    The list of cores over which to perform the estimation.
  */
 int
-CoreLoadEstimator::estimate(int curActiveCores) {
+CoreLoadEstimator::estimate(CorePolicy::CoreList coreList) {
     Lock guard(lock);
+    int curActiveCores = coreList.size();
     // Use collectionTime as a proxy to tell whether PerfStats have been
     // previously recorded.
     if (previousStats.collectionTime == 0) {
-        Arachne::PerfStats::collectStats(&previousStats);
+        Arachne::PerfStats::collectStats(&previousStats, coreList);
         return 0;
     }
     Arachne::PerfStats currentStats;
-    Arachne::PerfStats::collectStats(&currentStats);
+    Arachne::PerfStats::collectStats(&currentStats, coreList);
 
     // Evaluate idle time precentage multiplied by number of cores to
     // determine whether we need to decrease the number of cores.

--- a/src/CoreLoadEstimator.cc
+++ b/src/CoreLoadEstimator.cc
@@ -61,14 +61,6 @@ CoreLoadEstimator::estimate(CorePolicy::CoreList coreList) {
     previousStats = currentStats;
 
     if (estimationStrategy == LOAD_FACTOR) {
-        // We should not ramp down if we have a large number of blocked
-        // threads; these threads would have nowhere to migrate if we attempted
-        // to decrease core count.
-        double averageSlotUtilization =
-            static_cast<double>(currentStats.numThreadsCreated -
-                                currentStats.numThreadsFinished) /
-            (curActiveCores * Arachne::maxThreadsPerCore);
-
         // Scale down if the core utilization after scale down is greater than
         // the core utilization at which we scaled up, plus a hysteresis
         // threshold.
@@ -78,10 +70,9 @@ CoreLoadEstimator::estimate(CorePolicy::CoreList coreList) {
         ARACHNE_LOG(DEBUG,
                     "curActiveCores = %d, totalUtilizedCores = %lf, "
                     "localThreshold = %lf, averageloadFactor = %lf, "
-                    "loadFactorThreshold = %lf, averageSlotUtilization = %lf\n",
+                    "loadFactorThreshold = %lf\n",
                     curActiveCores, totalUtilizedCores, localThreshold,
-                    averageLoadFactor, loadFactorThreshold,
-                    averageSlotUtilization);
+                    averageLoadFactor, loadFactorThreshold);
 
         if (static_cast<size_t>(curActiveCores) <
                 utilizationThresholds.size() &&
@@ -92,24 +83,19 @@ CoreLoadEstimator::estimate(CorePolicy::CoreList coreList) {
             ARACHNE_LOG(NOTICE,
                         "Recommending increase core count: curActiveCores = "
                         "%d, totalUtilizedCores = %lf, localThreshold = %lf, "
-                        "averageloadFactor = %lf, loadFactorThreshold = %lf, "
-                        "averageSlotUtilization = %lf\n",
+                        "averageloadFactor = %lf, loadFactorThreshold = %lf\n",
                         curActiveCores, totalUtilizedCores, localThreshold,
-                        averageLoadFactor, loadFactorThreshold,
-                        averageSlotUtilization);
+                        averageLoadFactor, loadFactorThreshold);
             return 1;
         }
         localThreshold = std::max(zeroCoreUtilizationThreshold, localThreshold);
-        if ((totalUtilizedCores < localThreshold) &&
-            (averageSlotUtilization < slotOccupancyThreshold)) {
+        if ((totalUtilizedCores < localThreshold)) {
             ARACHNE_LOG(NOTICE,
                         "Recommending decrease core count: curActiveCores = "
                         "%d, totalUtilizedCores = %lf, localThreshold = %lf, "
-                        "averageloadFactor = %lf, loadFactorThreshold = %lf, "
-                        "averageSlotUtilization = %lf\n",
+                        "averageloadFactor = %lf, loadFactorThreshold = %lf\n",
                         curActiveCores, totalUtilizedCores, localThreshold,
-                        averageLoadFactor, loadFactorThreshold,
-                        averageSlotUtilization);
+                        averageLoadFactor, loadFactorThreshold);
             return -1;
         }
         return 0;

--- a/src/CoreLoadEstimator.h
+++ b/src/CoreLoadEstimator.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "CorePolicy.h"
 #include "PerfStats.h"
 
 namespace Arachne {
@@ -31,7 +32,7 @@ class CoreLoadEstimator {
   public:
     CoreLoadEstimator();
     ~CoreLoadEstimator();
-    int estimate(int currentNumCores);
+    int estimate(CorePolicy::CoreList coreList);
     void clearHistory();
     void setLoadFactorThreshold(double loadFactorThreshold);
     void setMaxUtilization(double maxUtilization);

--- a/src/DefaultCorePolicy.cc
+++ b/src/DefaultCorePolicy.cc
@@ -151,7 +151,7 @@ DefaultCorePolicy::adjustCores() {
             continue;
         }
         Lock guard(lock);
-        int estimate = loadEstimator.estimate(sharedCores.size());
+        int estimate = loadEstimator.estimate(sharedCores);
         if (estimate == 0)
             continue;
         if (estimate == -1) {


### PR DESCRIPTION
This allows the core load estimator to specify a corelist when asking
for PerfStats.

Since the availability of PerfStats in the main thread now depends on special
initialization, and thread creation requires PerfStats, this change also
eliminates testInit/testDestroy; their functionality has been rolled into
Arachne::init and Arachne::waitForTermination.