### PR TITLE
Fix up the build failure due to unused function chooseCore()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC ?= gcc
 CXXFLAGS=-g -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings \
 -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend \
 -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer \
--std=c++11 -fPIC -O3
+-std=c++11 -fPIC -O3 $(EXTRA_CXXFLAGS)
 CFLAGS=-g -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings \
 -Wno-unused-parameter -Wmissing-format-attribute \
 -Wcast-align -Wconversion -fomit-frame-pointer \

--- a/src/Arachne.h
+++ b/src/Arachne.h
@@ -456,7 +456,7 @@ random(void) {
 // refinement. This function is defined here to facilitate testing; defining it
 // in the CC file causes the compiler to generate an independent version of the
 // random() function above.
-static int
+static int __attribute__ ((unused))
 chooseCore(const CorePolicy::CoreList& coreList) {
     uint32_t index1 = static_cast<uint32_t>(random()) % coreList.size();
     uint32_t index2 = static_cast<uint32_t>(random()) % coreList.size();


### PR DESCRIPTION
This commit resolves the following build failure:

src/Arachne.h:460:1: error: ‘int Arachne::chooseCore(const
Arachne::CorePolicy::CoreList&)’ defined but not used
[-Werror=unused-function]
 chooseCore(const CorePolicy::CoreList& coreList) {
 ^~~~~~~~~~

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>