### PR TITLE
Make chooseCore() overloadable

### DIFF
--- a/src/Arachne.cc
+++ b/src/Arachne.cc
@@ -1524,7 +1524,7 @@ migrateThreadsFromCore() {
                 ARACHNE_LOG(ERROR, "No available cores to migrate threads to.");
                 abort();
             }
-            int coreId = chooseCore(outputCores);
+            int coreId = corePolicy->chooseCore(outputCores);
 
             bool success = false;
             uint8_t index;

--- a/src/CorePolicy.h
+++ b/src/CorePolicy.h
@@ -161,6 +161,14 @@ class CorePolicy {
      */
     virtual CoreList getCores(int threadClass) = 0;
 
+    /**
+     * Select a reasonably unloaded core from coreList using randomness with
+     * refinement. This function is defined here to facilitate testing; defining it
+     * in the CC file causes the compiler to generate an independent version of the
+     * random() function above.
+     */
+    virtual int chooseCore(const CoreList& coreList) = 0;
+
     virtual ~CorePolicy() {}
 };
 

--- a/src/DefaultCorePolicy.cc
+++ b/src/DefaultCorePolicy.cc
@@ -177,4 +177,27 @@ DefaultCorePolicy::adjustCores() {
         setCoreCount(Arachne::numActiveCores + 1);
     }
 }
+
+/**
+ * Select a reasonably unloaded core from coreList using randomness with
+ * refinement. This function is defined here to facilitate testing; defining it
+ * in the CC file causes the compiler to generate an independent version of the
+ * random() function above.
+ */
+int
+DefaultCorePolicy::chooseCore(const CorePolicy::CoreList& coreList) {
+    uint32_t index1 = static_cast<uint32_t>(random()) % coreList.size();
+    uint32_t index2 = static_cast<uint32_t>(random()) % coreList.size();
+    while (index2 == index1 && coreList.size() > 1)
+        index2 = static_cast<uint32_t>(random()) % coreList.size();
+
+    int choice1 = coreList.get(index1);
+    int choice2 = coreList.get(index2);
+
+    if (occupiedAndCount[choice1]->load().numOccupied <
+        occupiedAndCount[choice2]->load().numOccupied)
+        return choice1;
+    return choice2;
+}
+
 }  // namespace Arachne

--- a/src/DefaultCorePolicy.h
+++ b/src/DefaultCorePolicy.h
@@ -36,6 +36,7 @@ class DefaultCorePolicy : public CorePolicy {
     void disableLoadEstimation();
     void enableLoadEstimation();
     CoreLoadEstimator* getEstimator();
+    int chooseCore(const CoreList& coreList);
 
     /**
      * Applications using this CorePolicy must create threads using one of


### PR DESCRIPTION
For an external core policy, chooseCore() should be overloadable.
It implements specific algorithm to select the appropriate core
from getCores() which is also overloadable for an external core
policy.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>