### PR TITLE
Fix the computation of localThreshold

### DIFF
--- a/src/CoreLoadEstimator.cc
+++ b/src/CoreLoadEstimator.cc
@@ -65,8 +65,9 @@ CoreLoadEstimator::estimate(CorePolicy::CoreList coreList) {
         // Scale down if the core utilization after scale down is greater than
         // the core utilization at which we scaled up, plus a hysteresis
         // threshold.
-        double localThreshold = utilizationThresholds[curActiveCores - 1] -
-                                idleCoreFractionHysteresis;
+        double localThreshold =
+            utilizationThresholds[curActiveCores - 1] -
+            idleCoreFractionHysteresis * (curActiveCores - 1);
 
         ARACHNE_LOG(DEBUG,
                     "curActiveCores = %d, totalUtilizedCores = %lf, "

--- a/src/CoreLoadEstimator.h
+++ b/src/CoreLoadEstimator.h
@@ -83,7 +83,7 @@ class CoreLoadEstimator {
     std::vector<double> utilizationThresholds;
 
     /*
-     * The difference in load, expressed as a fraction of a core, between a
+     * The difference in load, expressed as a utilization delta, between a
      * ramp-down threshold and the corresponding ramp-up threshold (i.e., we
      * wait to ramp down until the load gets a bit below the point at
      * which we ramped up).


### PR DESCRIPTION
As disscussed, we should use the hysteresis as a relative threshold to avoid
oscillation and ramp down issue.