### PR TITLE
Fixed incorrect va_list usage

### DIFF
--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -62,8 +62,8 @@ Logger::log(LogLevel level, const char* fmt, ...) {
     spaceLeft -= actual;
 
     // Add the intended message
-    va_list args;
-    va_start(args, fmt);
+    //va_list args;
+    va_start(va_list args, fmt);
     actual = vsnprintf(buffer + charsWritten, spaceLeft, fmt, args);
     va_end(args);
 


### PR DESCRIPTION
Fixed incorrect va_list usage

Fixed issue #72.
This commit is to fix the incorrect va_list usage in ./Logger.cc file.

**Changelog**
- Fixed a build error
  : (error) va_list 'args' used before va_start() was called

Signed-off-by: Geunsik Lim <leemgs@gmail.com>